### PR TITLE
update block attributes used on pull quote block

### DIFF
--- a/class-block-unit-test.php
+++ b/class-block-unit-test.php
@@ -581,13 +581,16 @@ class Block_Unit_Test {
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph -->
-			<p>Here is an example of the core pull quote block, set to display centered. Nulla vitae elit libero, a pharetra augue. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+			<p>Here is an example of the core pull quote block; displays in the center by default. Nulla vitae elit libero, a pharetra augue. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
 			<!-- /wp:paragraph -->
 
-			<!-- wp:pullquote {"align":"center"} -->
-			<blockquote class="wp-block-pullquote aligncenter">
-				<p>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Sed posuere est at lobortis.</p><cite>Rich Tabor, ThemeBeans.com</cite></blockquote>
+			<!-- wp:pullquote -->
+			<figure class="wp-block-pullquote"><blockquote><p>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Sed posuere est at lobortis.</p><cite>Rich Tabor, ThemeBeans.com/cite&gt;</cite></blockquote></figure>
 			<!-- /wp:pullquote -->
+		';
+
+		if ( get_theme_support( 'align-wide' ) ) {
+			$content .= '
 
 			<!-- wp:heading {"level":3} -->
 			<h3>' . esc_html__( 'Wide aligned', '@@textdomain' ) . '</h3>
@@ -596,14 +599,10 @@ class Block_Unit_Test {
 			<!-- wp:paragraph -->
 			<p>Here is an example of the core pull quote block, set to display with the wide-aligned attribute, if the theme allows it. Nulla vitae elit libero, a pharetra augue. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
 			<!-- /wp:paragraph -->
-		';
 
-		if ( get_theme_support( 'align-wide' ) ) {
-			$content .= '
-				<!-- wp:pullquote {"align":"wide"} -->
-				<blockquote class="wp-block-pullquote alignwide">
-					<p>Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Aenean lacinia bibendum nulla sed ibendum nulla sed consectetur. </p><cite>Rich Tabor, Founder at ThemeBeans.com</cite></blockquote>
-				<!-- /wp:pullquote -->
+			<!-- wp:pullquote {"align":"wide"} -->
+			<figure class="wp-block-pullquote alignwide"><blockquote><p>Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Aenean lacinia bibendum nulla sed ibendum nulla sed consectetur.</p><cite>Rich Tabor</cite></blockquote></figure>
+			<!-- /wp:pullquote -->
 
 				<!-- wp:heading {"level":3} -->
 				<h3>' . esc_html__( 'Full width', '@@textdomain' ) . '</h3>
@@ -614,8 +613,7 @@ class Block_Unit_Test {
 				<!-- /wp:paragraph -->
 
 				<!-- wp:pullquote {"align":"full"} -->
-				<blockquote class="wp-block-pullquote alignfull">
-					<p>Etiam porta sem malesuada magna mollis euismod. Sed posuere consectetur est at lobortis. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. </p><cite>Rich Tabor, Founder at ThemeBeans.com</cite></blockquote>
+				<figure class="wp-block-pullquote alignfull"><blockquote><p>Etiam porta sem malesuada magna mollis euismod. Sed posuere consectetur est at lobortis. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus</p><cite>Rich Tabor, founder at Themebeans.com</cite></blockquote></figure>
 				<!-- /wp:pullquote -->
 
 				<!-- wp:paragraph -->
@@ -626,17 +624,16 @@ class Block_Unit_Test {
 
 		$content .= '
 			<!-- wp:pullquote {"align":"left"} -->
-			<blockquote class="wp-block-pullquote alignleft">
-				<p>Here we have a left-aligned pullquote.</p><cite>Rich Tabor</cite></blockquote>
+			<figure class="wp-block-pullquote alignleft"><blockquote><p>Here is a pull quote whose container is left-aligned. </p><cite>Rich Tabor</cite></blockquote></figure>
 			<!-- /wp:pullquote -->
+
 
 			<!-- wp:paragraph -->
 			<p>Donec id elit non mi porta gravida at eget metus. Nullam quis risus eget urna mollis ornare vel eu leo. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Cras mattis consectetur purus sit amet fermentum. Vestibulum id ligula porta felis euismod semper.</p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:pullquote {"align":"right"} -->
-			<blockquote class="wp-block-pullquote alignright">
-				<p>Here we have a right-aligned pullquote.</p><cite>Rich Tabor</cite></blockquote>
+			<figure class="wp-block-pullquote alignright"><blockquote><p>Here\'s a pull quote whose container is right-aligned. I\'m adding another line of text for effect.</p><cite>Will Skora</cite></blockquote></figure>
 			<!-- /wp:pullquote -->
 
 			<!-- wp:paragraph -->


### PR DESCRIPTION
The attributes and HTML used for Pull quote blocks in core have changed; ref https://github.com/skorasaurus/block-unit-test/issues/1


I also moved a couple blocks so that the ones that have wide attributes, are included under the get_theme_support (align-) statement
