### PR TITLE
Add new image blocks that contain the updated markup from core 

### DIFF
--- a/class-block-unit-test.php
+++ b/class-block-unit-test.php
@@ -581,13 +581,16 @@ class Block_Unit_Test {
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph -->
-			<p>Here is an example of the core pull quote block, set to display centered. Nulla vitae elit libero, a pharetra augue. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+			<p>Here is an example of the core pull quote block; displays in the center by default. Nulla vitae elit libero, a pharetra augue. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
 			<!-- /wp:paragraph -->
 
-			<!-- wp:pullquote {"align":"center"} -->
-			<blockquote class="wp-block-pullquote aligncenter">
-				<p>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Sed posuere est at lobortis.</p><cite>Rich Tabor, ThemeBeans.com</cite></blockquote>
+			<!-- wp:pullquote -->
+			<figure class="wp-block-pullquote"><blockquote><p>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Sed posuere est at lobortis.</p><cite>Rich Tabor, ThemeBeans.com/cite&gt;</cite></blockquote></figure>
 			<!-- /wp:pullquote -->
+		';
+
+		if ( get_theme_support( 'align-wide' ) ) {
+			$content .= '
 
 			<!-- wp:heading {"level":3} -->
 			<h3>' . esc_html__( 'Wide aligned', '@@textdomain' ) . '</h3>
@@ -596,14 +599,10 @@ class Block_Unit_Test {
 			<!-- wp:paragraph -->
 			<p>Here is an example of the core pull quote block, set to display with the wide-aligned attribute, if the theme allows it. Nulla vitae elit libero, a pharetra augue. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
 			<!-- /wp:paragraph -->
-		';
 
-		if ( get_theme_support( 'align-wide' ) ) {
-			$content .= '
-				<!-- wp:pullquote {"align":"wide"} -->
-				<blockquote class="wp-block-pullquote alignwide">
-					<p>Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Aenean lacinia bibendum nulla sed ibendum nulla sed consectetur. </p><cite>Rich Tabor, Founder at ThemeBeans.com</cite></blockquote>
-				<!-- /wp:pullquote -->
+			<!-- wp:pullquote {"align":"wide"} -->
+			<figure class="wp-block-pullquote alignwide"><blockquote><p>Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Aenean lacinia bibendum nulla sed ibendum nulla sed consectetur.</p><cite>Rich Tabor</cite></blockquote></figure>
+			<!-- /wp:pullquote -->
 
 				<!-- wp:heading {"level":3} -->
 				<h3>' . esc_html__( 'Full width', '@@textdomain' ) . '</h3>
@@ -614,8 +613,7 @@ class Block_Unit_Test {
 				<!-- /wp:paragraph -->
 
 				<!-- wp:pullquote {"align":"full"} -->
-				<blockquote class="wp-block-pullquote alignfull">
-					<p>Etiam porta sem malesuada magna mollis euismod. Sed posuere consectetur est at lobortis. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. </p><cite>Rich Tabor, Founder at ThemeBeans.com</cite></blockquote>
+				<figure class="wp-block-pullquote alignfull"><blockquote><p>Etiam porta sem malesuada magna mollis euismod. Sed posuere consectetur est at lobortis. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus</p><cite>Rich Tabor, founder at Themebeans.com</cite></blockquote></figure>
 				<!-- /wp:pullquote -->
 
 				<!-- wp:paragraph -->
@@ -626,17 +624,16 @@ class Block_Unit_Test {
 
 		$content .= '
 			<!-- wp:pullquote {"align":"left"} -->
-			<blockquote class="wp-block-pullquote alignleft">
-				<p>Here we have a left-aligned pullquote.</p><cite>Rich Tabor</cite></blockquote>
+			<figure class="wp-block-pullquote alignleft"><blockquote><p>Here is a pull quote whose container is left-aligned. </p><cite>Rich Tabor</cite></blockquote></figure>
 			<!-- /wp:pullquote -->
+
 
 			<!-- wp:paragraph -->
 			<p>Donec id elit non mi porta gravida at eget metus. Nullam quis risus eget urna mollis ornare vel eu leo. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Cras mattis consectetur purus sit amet fermentum. Vestibulum id ligula porta felis euismod semper.</p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:pullquote {"align":"right"} -->
-			<blockquote class="wp-block-pullquote alignright">
-				<p>Here we have a right-aligned pullquote.</p><cite>Rich Tabor</cite></blockquote>
+			<figure class="wp-block-pullquote alignright"><blockquote><p>Here\'s a pull quote whose container is right-aligned. I\'m adding another line of text for effect.</p><cite>Will Skora</cite></blockquote></figure>
 			<!-- /wp:pullquote -->
 
 			<!-- wp:paragraph -->

--- a/class-block-unit-test.php
+++ b/class-block-unit-test.php
@@ -645,7 +645,7 @@ class Block_Unit_Test {
 			<!-- /wp:separator -->
 
 			<!-- wp:heading {"level":2} -->
-			<h2>Image Block</h2>
+			<h2>Image Blocks</h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph -->
@@ -658,8 +658,12 @@ class Block_Unit_Test {
 
 			<!-- wp:image {"id":2117,"align":"center"} -->
 				<figure class="wp-block-image aligncenter"><img src="' . esc_url( $this->url . '/placeholder.jpg' ) . '" alt="" class="wp-image-2117" />
-					<figcaption>And an image with a caption</figcaption>
+					<figcaption>A caption, features older block markup circa 2019.</figcaption>
 				</figure>
+			<!-- /wp:image -->
+
+			<!-- wp:image {"align":"center","id":13,"sizeSlug":"full","linkDestination":"none"} -->
+			<div class="wp-block-image"><figure class="aligncenter size-full"><img src="' . esc_url( $this->url . '/placeholder.jpg' ) . '"  alt="" class="wp-image-13"/><figcaption>Center aligned; image block markup from Gutenberg 11.5</figcaption></figure></div>
 			<!-- /wp:image -->
 		';
 
@@ -695,14 +699,27 @@ class Block_Unit_Test {
 			<!-- /wp:image -->
 
 			<!-- wp:paragraph -->
-			<p><strong>Left aligned:</strong> dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. </p>
+			<p>Image block with left alignment and markup as of Gutenberg 11.5 (Mid 2021) immediately follows this paragraph block.</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:image {"align":"left","id":13,"sizeSlug":"medium","linkDestination":"none"} -->
+			<div class="wp-block-image"><figure class="alignleft size-medium"><img src="' . esc_url( $this->url . '/placeholder.jpg' ) . '" alt="" class="wp-image-13"/></figure></div>
+			<!-- /wp:image -->
+
+			<!-- wp:paragraph -->
+			<p>dimentum nibh, ut fermentum massa justo sit amet risus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. </p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:image {"id":2117,"align":"right","width":281,"height":200} -->
 			<figure class="wp-block-image alignright is-resized"><img src="' . esc_url( $this->url . '/placeholder.jpg' ) . '" alt="" class="wp-image-2117" width="281" height="200" />
-				<figcaption>This one is captioned</figcaption>
+				<figcaption>Image block, right aligned, block markup circa 2019.</figcaption>
 			</figure>
 			<!-- /wp:image -->
+
+			<!-- wp:image {"align":"right","id":15,"sizeSlug":"full","linkDestination":"none"} -->
+			<div class="wp-block-image"><figure class="alignright size-full"><img src="' . esc_url( $this->url . '/placeholder.jpg' ) . '"alt="" class="wp-image-15"/><figcaption>Image block, right aligned with block markup as of Gutenberg 11.5</figcaption></figure></div>
+			<!-- /wp:image -->
+
 
 			<!-- wp:paragraph -->
 			<p>Nullam quis risus eget urna mollis ornare vel eu leo. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Nullam quis risus.</p>

--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,11 @@
   "name": "godaddy-wordpress/block-unit-test",
   "license": "GPL-2.0-only",
   "require": {
-    "php": ">=5.6"
+    "php": ">=7.2"
   },
   "config": {
     "platform": {
-      "php": "5.6"
+      "php": "7.3"
     }
   },
   "scripts": {
@@ -14,8 +14,8 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.5",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-    "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "wp-coding-standards/wpcs": "^2.1"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+    "phpcompatibility/phpcompatibility-wp": "^2.1.2",
+    "wp-coding-standards/wpcs": "^2.3"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0bc9d4e83b9a142b95022b11dd41bca1",
+    "content-hash": "34ccba1145c8e75e816ca9b090665821",
     "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.5.0",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "^2|^3"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
@@ -71,7 +71,11 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2018-10-26T13:21:45+00:00"
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -129,32 +133,36 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
             "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
-                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
                 "paragonie/random_compat": "dev-master",
                 "paragonie/sodium_compat": "dev-master"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -181,20 +189,24 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2019-11-04T15:17:54+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "time": "2021-02-15T10:24:51+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.0",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f"
+                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/41bef18ba688af638b7310666db28e1ea9158b2f",
-                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/a792ab623069f0ce971b2417edef8d9632e32f75",
+                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75",
                 "shasum": ""
             },
             "require": {
@@ -202,10 +214,10 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -231,20 +243,24 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-08-28T14:22:28+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "time": "2021-07-21T11:09:57+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -282,20 +298,25 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.2.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b5a453203114cc2284b1a614c4953456fbe4f546",
-                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
@@ -305,6 +326,7 @@
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
@@ -327,7 +349,12 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2020-02-04T02:52:06+00:00"
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "aliases": [],
@@ -336,11 +363,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6"
+        "php": ">=7.2"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6"
+        "php": "7.3"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION

Image blocks in Gutenberg now have different markup; I've added the blocks with the new markup. I did keep the existing image blocks. 

some image blocks, depending on the align attribute are now wrapped a div. 

ref https://github.com/skorasaurus/block-unit-test/issues/2