### PR TITLE
add conditional for detecting wide-align support declared through theme.json

### DIFF
--- a/class-block-unit-test.php
+++ b/class-block-unit-test.php
@@ -210,6 +210,9 @@ class Block_Unit_Test {
 	 */
 	public function content() {
 
+		$layout_settings = gutenberg_get_global_settings(array( 'layout' ));
+		$content_size_in_theme_json = $layout_settings['contentSize'];
+
 		$content = '';
 
 		$content .= '
@@ -598,7 +601,7 @@ class Block_Unit_Test {
 			<!-- /wp:paragraph -->
 		';
 
-		if ( get_theme_support( 'align-wide' ) ) {
+		if ( get_theme_support( 'align-wide' )  || isset( $content_size_in_theme_json ) ) {
 			$content .= '
 				<!-- wp:pullquote {"align":"wide"} -->
 				<blockquote class="wp-block-pullquote alignwide">
@@ -666,7 +669,7 @@ class Block_Unit_Test {
 			<!-- /wp:image -->
 		';
 
-		if ( get_theme_support( 'align-wide' ) ) {
+		if ( get_theme_support( 'align-wide' )  || isset(  $content_size_in_theme_json )  || isset(  $content_size_in_theme_json ) ) {
 			$content .= '
 				<!-- wp:heading {"level":3} -->
 				<h3>' . esc_html__( 'Wide aligned', '@@textdomain' ) . '</h3>
@@ -724,7 +727,7 @@ class Block_Unit_Test {
 			<!-- /wp:paragraph -->
 		';
 
-		if ( get_theme_support( 'align-wide' ) ) {
+		if ( get_theme_support( 'align-wide' )  || isset( $content_size_in_theme_json ) ) {
 			$content .= '
 				<!-- wp:heading {"level":3} -->
 				<h3>' . esc_html__( 'Wide aligned', '@@textdomain' ) . '</h3>
@@ -760,7 +763,7 @@ class Block_Unit_Test {
 
 		';
 
-		if ( get_theme_support( 'align-wide' ) ) {
+		if ( get_theme_support( 'align-wide' )  || isset( $content_size_in_theme_json ) ) {
 			$content .= '
 				<!-- wp:heading {"level":3} -->
 				<h3>' . esc_html__( 'Wide aligned', '@@textdomain' ) . '</h3>
@@ -1037,7 +1040,7 @@ class Block_Unit_Test {
 			<!-- /wp:gallery -->
 		';
 
-		if ( get_theme_support( 'align-wide' ) ) {
+		if ( get_theme_support( 'align-wide' )  || isset(  $content_size_in_theme_json ) ) {
 			$content .= '
 				<!-- wp:heading {"level":2} -->
 				<h2>Wide aligned Gallery Blocks</h2>

--- a/class-block-unit-test.php
+++ b/class-block-unit-test.php
@@ -210,7 +210,7 @@ class Block_Unit_Test {
 	 */
 	public function content() {
 
-		$layout_settings = gutenberg_get_global_settings(array( 'layout' ));
+		$layout_settings = wp_get_global_settings(array( 'layout' ));
 		$content_size_in_theme_json = $layout_settings['contentSize'];
 
 		$content = '';

--- a/class-block-unit-test.php
+++ b/class-block-unit-test.php
@@ -669,7 +669,7 @@ class Block_Unit_Test {
 			<!-- /wp:image -->
 		';
 
-		if ( get_theme_support( 'align-wide' )  || isset(  $content_size_in_theme_json )  || isset(  $content_size_in_theme_json ) ) {
+		if ( get_theme_support( 'align-wide' )  || isset(  $content_size_in_theme_json )  ) {
 			$content .= '
 				<!-- wp:heading {"level":3} -->
 				<h3>' . esc_html__( 'Wide aligned', '@@textdomain' ) . '</h3>


### PR DESCRIPTION
This is based on https://github.com/WordPress/gutenberg/pull/34843 which has been merged and is included in wordpress 5.9

I've tested it and the wide-aligned blocks will appear on the page. Additional background at https://github.com/godaddy-wordpress/block-unit-test/issues/10

The function was later renamed in https://github.com/WordPress/gutenberg/pull/36907 and required an additional commit. 

To test: 

1. Use twentytwentyone theme; 
2. delete add_theme_support('align-wide') line from functions.php of that theme
3. add this [theme.json](https://gist.github.com/skorasaurus/acda2ea50cf4e4b5581a05968bf7efeb) to theme folder (it creates support for wide-align block) 
4. build block-unit-test from this PR; activate plugin. 


